### PR TITLE
Update MMSoapClient.php to prevent error

### DIFF
--- a/mmsoap/MMSoapClient.php
+++ b/mmsoap/MMSoapClient.php
@@ -22,7 +22,7 @@ class MMSoapClient extends SoapClient {
         parent::__construct($wsdl, $options);
     }
 
-    public function __doRequest($request, $location, $action, $version) {
+    public function __doRequest($request, $location, $action, $version, $one_way = 0) {
         $dom = new DOMDocument('1.0');
 
         // loads the SOAP request to the Document


### PR DESCRIPTION
If someone sets their error handling to strict, this will fail because the child method is not a proper implementation of the extended Class.  Since a return response is expected, one way is set to zero.