### PR TITLE
adding the missing parameter to the parent method of MMSoapClient class

### DIFF
--- a/mmsoap/MMSoapClient.php
+++ b/mmsoap/MMSoapClient.php
@@ -37,7 +37,7 @@ class MMSoapClient extends SoapClient {
         // Save the modified SOAP request
         $request = $dom->saveXML();
 
-        $response = parent::__doRequest($request, $location, $action, $version);
+        $response = parent::__doRequest($request, $location, $action, $version, $one_way);
         // fix & bug which causes the following warning;
         // PHP Warning:  DOMDocument::createElement(): unterminated entity reference 
         $response = str_replace('&', '&amp;', $response);


### PR DESCRIPTION
Adding the missing $one_way parameter to the doRequest method when calling parent class method.